### PR TITLE
do not remove the file on Unlock()

### DIFF
--- a/flock_test.go
+++ b/flock_test.go
@@ -108,9 +108,6 @@ func (t *TestSuite) TestFlock_Unlock(c *C) {
 	err = t.flock.Unlock()
 	c.Assert(err, IsNil)
 	c.Check(t.flock.Locked(), Equals, false)
-
-	_, err = os.Stat(t.path)
-	c.Assert(os.IsNotExist(err), Equals, true)
 }
 
 func (t *TestSuite) TestFlock_Lock(c *C) {


### PR DESCRIPTION
This operation doesn't appear to be as atomic as I had hoped. It's causing some issues.