### PR TITLE
Update TravisCI to test against the latest Go 1.9.x and 1.8.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: go
 go:
-  - 1.5
+  - 1.9.2
+  - 1.8.5
 script: go test -v ./... -check.vv
 sudo: false
 notifications:


### PR DESCRIPTION
There have been some language changes since Go 1.5 that could cause valid Go
code to fail and compile, specifically if contexts were to be used.

This updates the TravisCI configuration to test against the two supported
versions of the Go runtime/toolkit.